### PR TITLE
cmake: adapt library install dir according to the host OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ if(WIN32)
   set(LIBARGTABLE2_LIB_DIR "bin")
 else()
   add_library(${PROJECT_NAME} SHARED src/arg_date.c src/arg_dbl.c src/arg_end.c src/arg_file.c src/arg_int.c src/arg_uint.c src/arg_lit.c src/arg_rem.c src/arg_rex.c src/arg_str.c src/argtable2.c src/getopt.c src/getopt1.c)
-  set(LIBARGTABLE2_LIB_DIR "lib")
+  include(GNUInstallDirs)
+  set(LIBARGTABLE2_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 # Ensure clients can find the includes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,10 @@ project(argtable2)
 # Create a shared library
 if(WIN32)
   add_library(${PROJECT_NAME} SHARED                src/arg_dbl.c src/arg_end.c src/arg_file.c src/arg_int.c src/arg_uint.c src/arg_lit.c src/arg_rem.c               src/arg_str.c src/argtable2.c src/getopt.c src/getopt1.c src/argtable2.def)
+  set(LIBARGTABLE2_LIB_DIR "bin")
 else()
   add_library(${PROJECT_NAME} SHARED src/arg_date.c src/arg_dbl.c src/arg_end.c src/arg_file.c src/arg_int.c src/arg_uint.c src/arg_lit.c src/arg_rem.c src/arg_rex.c src/arg_str.c src/argtable2.c src/getopt.c src/getopt1.c)
+  set(LIBARGTABLE2_LIB_DIR "lib")
 endif()
 
 # Ensure clients can find the includes
@@ -13,8 +15,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC include)
 # What to install
 install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin
-  LIBRARY DESTINATION bin
-  ARCHIVE DESTINATION bin
+  LIBRARY DESTINATION ${LIBARGTABLE2_LIB_DIR}
+  ARCHIVE DESTINATION ${LIBARGTABLE2_LIB_DIR}
 )
 install(
   DIRECTORY include/sheitmann DESTINATION include


### PR DESCRIPTION
By default, and for a windows target,  libraries are usually installed in `bin` directory. But for linux target OS the usual place is `lib`.
This PR add an cmake variable pointing to `bin` or `lib` according to the host system, and used in the install rule.