### PR TITLE
add pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,3 +19,13 @@ install(TARGETS ${PROJECT_NAME}
 install(
   DIRECTORY include/sheitmann DESTINATION include
 )
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libargtable2.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libargtable2.pc
+@ONLY)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/libargtable2.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/libargtable2.pc.in
+++ b/libargtable2.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: libargtable2
+Description: A makestuff build of Stewart Heitmann's argtable2.
+Version: 20170708
+Libs: -L${libdir} -largtable2
+Cflags: -I${includedir}
+


### PR DESCRIPTION
One classic way to detect and to obtain required parameters at build time requirements, to use a library, is through `pkg-config`.
This approach is Linux and msys2 compatible.
This PR add a pc.in file filled with prefix and all required informations, this one is installed in `${CMAKE_INSTALL_LIBDIR}/pkgconfig`